### PR TITLE
Bump Mongoose version to 5.9.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "casbin": "4.1.1",
-    "mongoose": "5.9.1"
+    "mongoose": "5.9.16"
   },
   "peerDependencies": {
     "casbin": "^4.1.1"


### PR DESCRIPTION
Latest MongoDB drivers eliminate circular dependency warnings when using Node 14. 

```
(node:96052) Warning: Accessing non-existent property 'count' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:96052) Warning: Accessing non-existent property 'findOne' of module exports inside circular dependency
(node:96052) Warning: Accessing non-existent property 'remove' of module exports inside circular dependency
(node:96052) Warning: Accessing non-existent property 'updateOne' of module exports inside circular dependency
```