### PR TITLE
Upgrade mongoose to ^5.11.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: node_js
 
 node_js:
   - '10'
-  - '11'
   - '12'
+  - '14'
   - 'stable'
 
 install: npm install
 
 before_script:
 # Stop current mongo
-- sudo systemctl stop mongod 
+- sudo systemctl stop mongod
 
 # Begin modification of the default mongoDB instance
 - sudo cp .travis/mongo.conf /etc/mongodb.conf
@@ -52,7 +52,7 @@ before_script:
 - |
   mongo --quiet --eval 'rs.initiate({_id:"rs0", members: [{"_id":0, "host":"travis:27017"},{"_id":1, "host":"travis:27018"}]})'
 - mongo --quiet --port 27017 .travis/rs_status.js || { sudo cat /tmp/mongodb_rs0.log; sudo cat /tmp/mongodb_rs1.log; exit 1; }
-- mongo --quiet --eval 'rs.status()' 
+- mongo --quiet --eval 'rs.status()'
 
 script:
   - echo "Running tests against $(node -v)..."

--- a/API.md
+++ b/API.md
@@ -37,7 +37,9 @@ Implements a policy adapter for casbin with MongoDB support.
 <a name="new_MongooseAdapter_new"></a>
 
 ### new MongooseAdapter(uri, [options])
-Creates a new instance of mongoose adapter for casbin.It does not wait for successfull connection to MongoDB.So, if you want to have a possibility to wait until connection successful, use newAdapter instead.
+Creates a new instance of mongoose adapter for casbin.
+It does not wait for successfull connection to MongoDB.
+So, if you want to have a possibility to wait until connection successful, use newAdapter instead.
 
 
 | Param | Type | Default | Description |
@@ -47,7 +49,8 @@ Creates a new instance of mongoose adapter for casbin.It does not wait for succ
 
 **Example**  
 ```js
-const adapter = new MongooseAdapter('MONGO_URI');const adapter = new MongooseAdapter('MONGO_URI', { mongoose_options: 'here' })
+const adapter = new MongooseAdapter('MONGO_URI');
+const adapter = new MongooseAdapter('MONGO_URI', { mongoose_options: 'here' })
 ```
 <a name="MongooseAdapter+_open"></a>
 
@@ -58,7 +61,8 @@ Opens a connection to mongoDB
 <a name="MongooseAdapter+setFiltered"></a>
 
 ### mongooseAdapter.setFiltered([enable])
-Switch adapter to (non)filtered state.Casbin uses this flag to determine if it should load the whole policy from DB or not.
+Switch adapter to (non)filtered state.
+Casbin uses this flag to determine if it should load the whole policy from DB or not.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -75,7 +79,8 @@ isFiltered determines whether the filtered model is enabled for the adapter.
 <a name="MongooseAdapter+setSynced"></a>
 
 ### mongooseAdapter.setSynced([synced])
-SyncedAdapter: Switch adapter to (non)synced state.This enables mongoDB transactions when loading and saving policies to DB.
+SyncedAdapter: Switch adapter to (non)synced state.
+This enables mongoDB transactions when loading and saving policies to DB.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -86,7 +91,8 @@ SyncedAdapter: Switch adapter to (non)synced state.This enables mongoDB transac
 <a name="MongooseAdapter+setAutoAbort"></a>
 
 ### mongooseAdapter.setAutoAbort([abort])
-SyncedAdapter: Automatically abort on Error.When enabled, functions will automatically abort on error
+SyncedAdapter: Automatically abort on Error.
+When enabled, functions will automatically abort on error
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -97,7 +103,8 @@ SyncedAdapter: Automatically abort on Error.When enabled, functions will automa
 <a name="MongooseAdapter+setAutoCommit"></a>
 
 ### mongooseAdapter.setAutoCommit([commit])
-SyncedAdapter: Automatically commit after each addition.When enabled, functions will automatically commit after function has finished
+SyncedAdapter: Automatically commit after each addition.
+When enabled, functions will automatically commit after function has finished
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -120,26 +127,30 @@ SyncedAdapter: Sets current session to specific one. Do not use this unless you 
 <a name="MongooseAdapter+getTransaction"></a>
 
 ### mongooseAdapter.getTransaction() ⇒ <code>Promise.&lt;Session&gt;</code>
-SyncedAdapter: Gets active transaction or starts a new one. Transaction must be closed before changes are doneto the database. See: commitTransaction, abortTransaction
+SyncedAdapter: Gets active transaction or starts a new one. Transaction must be closed before changes are done
+to the database. See: commitTransaction, abortTransaction
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 **Returns**: <code>Promise.&lt;Session&gt;</code> - Returns a session with active transaction  
 <a name="MongooseAdapter+commitTransaction"></a>
 
 ### mongooseAdapter.commitTransaction() ⇒ <code>Promise.&lt;void&gt;</code>
-SyncedAdapter: Commits active transaction. Documents are not saved before this function is used.Transaction closes after the use of this function.
+SyncedAdapter: Commits active transaction. Documents are not saved before this function is used.
+Transaction closes after the use of this function.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 <a name="MongooseAdapter+abortTransaction"></a>
 
 ### mongooseAdapter.abortTransaction() ⇒ <code>Promise.&lt;void&gt;</code>
-SyncedAdapter: Aborts active transaction. All Document changes within this transaction are reverted.Transaction closes after the use of this function.
+SyncedAdapter: Aborts active transaction. All Document changes within this transaction are reverted.
+Transaction closes after the use of this function.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 <a name="MongooseAdapter+loadPolicyLine"></a>
 
 ### mongooseAdapter.loadPolicyLine(line, model)
-Loads one policy rule into casbin model.This method is used by casbin and should not be called by user.
+Loads one policy rule into casbin model.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -151,7 +162,8 @@ Loads one policy rule into casbin model.This method is used by casbin and shoul
 <a name="MongooseAdapter+loadPolicy"></a>
 
 ### mongooseAdapter.loadPolicy(model) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of loading policy from database into enforcer.This method is used by casbin and should not be called by user.
+Implements the process of loading policy from database into enforcer.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -162,7 +174,8 @@ Implements the process of loading policy from database into enforcer.This metho
 <a name="MongooseAdapter+loadFilteredPolicy"></a>
 
 ### mongooseAdapter.loadFilteredPolicy(model, [filter])
-Loads partial policy based on filter criteria.This method is used by casbin and should not be called by user.
+Loads partial policy based on filter criteria.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -174,7 +187,9 @@ Loads partial policy based on filter criteria.This method is used by casbin and
 <a name="MongooseAdapter+savePolicyLine"></a>
 
 ### mongooseAdapter.savePolicyLine(ptype, rule) ⇒ <code>Object</code>
-Generates one policy rule ready to be saved into MongoDB.This method is used by casbin to generate Mongoose Model Object for single policyand should not be called by user.
+Generates one policy rule ready to be saved into MongoDB.
+This method is used by casbin to generate Mongoose Model Object for single policy
+and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 **Returns**: <code>Object</code> - Returns a created CasbinRule record for MongoDB  
@@ -187,7 +202,11 @@ Generates one policy rule ready to be saved into MongoDB.This method is used by
 <a name="MongooseAdapter+savePolicy"></a>
 
 ### mongooseAdapter.savePolicy(model) ⇒ <code>Promise.&lt;Boolean&gt;</code>
-Implements the process of saving policy from enforcer into database.If you are using replica sets with mongo, this function will use mongotransaction, so every line in the policy needs tosucceed for this totake effect.This method is used by casbin and should not be called by user.
+Implements the process of saving policy from enforcer into database.
+If you are using replica sets with mongo, this function will use mongo
+transaction, so every line in the policy needs tosucceed for this to
+take effect.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -198,7 +217,8 @@ Implements the process of saving policy from enforcer into database.If you are 
 <a name="MongooseAdapter+addPolicy"></a>
 
 ### mongooseAdapter.addPolicy(sec, ptype, rule) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of adding policy rule.This method is used by casbin and should not be called by user.
+Implements the process of adding policy rule.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -211,7 +231,8 @@ Implements the process of adding policy rule.This method is used by casbin and 
 <a name="MongooseAdapter+addPolicies"></a>
 
 ### mongooseAdapter.addPolicies(sec, ptype, rule) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of adding a list of policy rules.This method is used by casbin and should not be called by user.
+Implements the process of adding a list of policy rules.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -224,7 +245,8 @@ Implements the process of adding a list of policy rules.This method is used by 
 <a name="MongooseAdapter+removePolicy"></a>
 
 ### mongooseAdapter.removePolicy(sec, ptype, rule) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of removing a list of policy rules.This method is used by casbin and should not be called by user.
+Implements the process of removing a list of policy rules.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -237,7 +259,8 @@ Implements the process of removing a list of policy rules.This method is used b
 <a name="MongooseAdapter+removePolicies"></a>
 
 ### mongooseAdapter.removePolicies(sec, ptype, rules) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of removing a policyList rules.This method is used by casbin and should not be called by user.
+Implements the process of removing a policyList rules.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -250,7 +273,8 @@ Implements the process of removing a policyList rules.This method is used by ca
 <a name="MongooseAdapter+removeFilteredPolicy"></a>
 
 ### mongooseAdapter.removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues) ⇒ <code>Promise.&lt;void&gt;</code>
-Implements the process of removing policy rules.This method is used by casbin and should not be called by user.
+Implements the process of removing policy rules.
+This method is used by casbin and should not be called by user.
 
 **Kind**: instance method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -264,7 +288,9 @@ Implements the process of removing policy rules.This method is used by casbin a
 <a name="MongooseAdapter.newAdapter"></a>
 
 ### MongooseAdapter.newAdapter(uri, [options], [adapterOptions])
-Creates a new instance of mongoose adapter for casbin.Instead of constructor, it does wait for successfull connection to MongoDB.Preferable way to construct an adapter instance, is to use this static method.
+Creates a new instance of mongoose adapter for casbin.
+Instead of constructor, it does wait for successfull connection to MongoDB.
+Preferable way to construct an adapter instance, is to use this static method.
 
 **Kind**: static method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -276,12 +302,15 @@ Creates a new instance of mongoose adapter for casbin.Instead of constructor, i
 
 **Example**  
 ```js
-const adapter = await MongooseAdapter.newAdapter('MONGO_URI');const adapter = await MongooseAdapter.newAdapter('MONGO_URI', { mongoose_options: 'here' });
+const adapter = await MongooseAdapter.newAdapter('MONGO_URI');
+const adapter = await MongooseAdapter.newAdapter('MONGO_URI', { mongoose_options: 'here' });
 ```
 <a name="MongooseAdapter.newFilteredAdapter"></a>
 
 ### MongooseAdapter.newFilteredAdapter(uri, [options])
-Creates a new instance of mongoose adapter for casbin.It does the same as newAdapter, but it also sets a flag that this adapter is in filtered state.That way, casbin will not call loadPolicy() automatically.
+Creates a new instance of mongoose adapter for casbin.
+It does the same as newAdapter, but it also sets a flag that this adapter is in filtered state.
+That way, casbin will not call loadPolicy() automatically.
 
 **Kind**: static method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -292,12 +321,16 @@ Creates a new instance of mongoose adapter for casbin.It does the same as newAd
 
 **Example**  
 ```js
-const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI');const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
+const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI');
+const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
 ```
 <a name="MongooseAdapter.newSyncedAdapter"></a>
 
 ### MongooseAdapter.newSyncedAdapter(uri, [options], autoAbort)
-Creates a new instance of mongoose adapter for casbin.It does the same as newAdapter, but it checks wether database is a replica set. If it is, it enablestransactions for the adapter.Transactions are never commited automatically. You have to use commitTransaction to add pending changes.
+Creates a new instance of mongoose adapter for casbin.
+It does the same as newAdapter, but it checks wether database is a replica set. If it is, it enables
+transactions for the adapter.
+Transactions are never commited automatically. You have to use commitTransaction to add pending changes.
 
 **Kind**: static method of [<code>MongooseAdapter</code>](#MongooseAdapter)  
 
@@ -309,5 +342,6 @@ Creates a new instance of mongoose adapter for casbin.It does the same as newAd
 
 **Example**  
 ```js
-const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI');const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
+const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI');
+const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
 ```

--- a/package.json
+++ b/package.json
@@ -53,23 +53,23 @@
   },
   "devDependencies": {
     "casbin": "^5.1.0",
-    "chai": "4.2.0",
+    "chai": "^4.3.0",
     "coveralls": "^3.0.9",
-    "cz-conventional-changelog": "3.0.2",
-    "eslint": "6.8.0",
-    "eslint-config-standard": "14.1.0",
-    "eslint-plugin-import": "2.20.1",
-    "eslint-plugin-node": "11.0.0",
-    "eslint-plugin-promise": "4.2.1",
-    "eslint-plugin-standard": "4.0.1",
-    "husky": "4.2.3",
-    "jsdoc-to-markdown": "5.0.3",
-    "mocha": "7.0.1",
-    "nyc": "15.0.0",
+    "cz-conventional-changelog": "^3.3.0",
+    "eslint": "^7.20.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.3.1",
+    "eslint-plugin-standard": "^5.0.0",
+    "husky": "^5.0.9",
+    "jsdoc-to-markdown": "^6.0.1",
+    "mocha": "^8.3.0",
+    "nyc": "^15.1.0",
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "mongoose": "5.9.16"
+    "mongoose": "^5.11.17"
   },
   "peerDependencies": {
     "casbin": "^5.0.7"


### PR DESCRIPTION
mongoose 5.9.16 depended on mquery 3.2.2 that has CVE-2020-35149.

devDependencies also gave warnings
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated debug@3.2.6: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated fsevents@2.1.3: "Please update to latest v2.3 or v2.2"