### PR TITLE
feat: allow multiple connections

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -311,7 +311,6 @@ export class MongooseAdapter {
    * @returns {Promise<void>}
    */
   async loadPolicy(model: Model) {
-    // console.log("loadPolicy", model)
     return this.loadFilteredPolicy(model, null);
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Schema, Document, model} from 'mongoose';
+import {Schema, Document} from 'mongoose';
 
 export interface IModel extends Document {
   p_type: string;
@@ -24,7 +24,7 @@ export interface IModel extends Document {
   v5: string;
 }
 
-const schema = new Schema({
+export const casbinRuleSchema = new Schema({
   p_type: {
     type: Schema.Types.String,
     required: true,
@@ -60,6 +60,5 @@ const schema = new Schema({
   timestamps: false
 });
 
-export const CasbinRule = model<IModel>('CasbinRule', schema, 'casbin_rule');
-
-export default CasbinRule
+export const MODEL_NAME = 'CasbinRule'
+export const COLLECTION_NAME = 'casbin_rule'

--- a/test/integration/adapter.test.js
+++ b/test/integration/adapter.test.js
@@ -36,7 +36,10 @@ const { InvalidAdapterTypeError } = require('../../lib/cjs/errors');
 // These tests are just smoke tests for get/set policy rules
 // We do not need to cover other aspects of casbin, since casbin itself is covered with tests
 describe('MongooseAdapter', () => {
+  let CasbinRule;
   beforeEach(async () => {
+    const adapter = await createAdapter();
+    CasbinRule = adapter._model();
     await createEnforcer();
     await CasbinRule.deleteMany();
   });
@@ -808,11 +811,11 @@ describe('MongooseAdapter', () => {
     // Create mongoAdapter
     const enforcer = await createEnforcer();
     const adapter = enforcer.getAdapter();
-    assert.equal(adapter.mongoseInstance.connection.readyState, 1, 'Connection should be open');
+    assert.equal(adapter.connection.readyState, 1, 'Connection should be open');
 
     // Connection should close
     await adapter.close();
-    assert.equal(adapter.mongoseInstance.connection.readyState, 0, 'Connection should be closed');
+    assert.equal(adapter.connection.readyState, 0, 'Connection should be closed');
   });
 
   it('Closing a closed/undefined connection should not raise an error', async () => {
@@ -820,6 +823,6 @@ describe('MongooseAdapter', () => {
     const adapter = await createDisconnectedAdapter();
     // Closing a closed connection should not raise an error
     await adapter.close();
-    assert.equal(adapter.mongoseInstance, undefined, 'mongoseInstance should be undefined');
+    assert.equal(adapter.connection, undefined, 'mongoseInstance should be undefined');
   });
 });

--- a/test/unit/adapter.test.js
+++ b/test/unit/adapter.test.js
@@ -31,6 +31,17 @@ describe('MongooseAdapter', () => {
     assert.isFalse(adapter.isFiltered());
   });
 
+  it('Should properly instantiate multiple adapters', async () => {
+    const adapter1 = new MongooseAdapter('mongodb://localhost:27001/casbin', { ...MONGOOSE_OPTIONS, autoCreate: true });
+    const adapter2 = new MongooseAdapter('mongodb://localhost:27001/casbin2', { ...MONGOOSE_OPTIONS, autoCreate: true });
+
+    assert.instanceOf(adapter1, MongooseAdapter);
+    assert.isFalse(adapter1.isFiltered());
+
+    assert.instanceOf(adapter2, MongooseAdapter);
+    assert.isFalse(adapter2.isFiltered());
+  });
+
   it('Should properly create new instance via static newAdapter', async () => {
     const adapter = await MongooseAdapter.newAdapter('mongodb://localhost:27001/casbin', MONGOOSE_OPTIONS);
 


### PR DESCRIPTION
This PR allows `casbin-mongoose-adapter` to instantiate multiple
connections to different connections strings. It makes it easier to test
code that depends on this adapter and give more flexibility to where casbin
policies will be stored.