### PR TITLE
fix: token parsing issues if token contains delimeter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2](https://github.com/node-casbin/mongoose-adapter/compare/v4.0.1...v4.0.2) (2022-02-27)
+
+
+### Bug Fixes
+
+* Schema p_type to ptype ([#56](https://github.com/node-casbin/mongoose-adapter/issues/56)) ([7a32166](https://github.com/node-casbin/mongoose-adapter/commit/7a321669a06d8761ea8a20b93dfb98a53f0c355f))
+
 ## [4.0.1](https://github.com/node-casbin/mongoose-adapter/compare/v4.0.0...v4.0.1) (2022-01-31)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin-mongoose-adapter",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Mongoose adapter for Casbin",
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin-mongoose-adapter",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Mongoose adapter for Casbin",
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",
@@ -56,7 +56,8 @@
     "build": "run-s clean && run-p build:*",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
-    "clean": "rimraf lib"
+    "clean": "rimraf lib",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.21.0",
@@ -79,10 +80,10 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "mongoose": "^6.0.12"
+    "mongoose": "^6.2.4"
   },
   "peerDependencies": {
-    "casbin": "^5.0.7"
+    "casbin": "^5.13.2"
   },
   "husky": {
     "hooks": {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {BatchAdapter, FilteredAdapter, Helper, logPrint, Model, UpdatableAdapter} from "casbin";
-import {ConnectOptions, Mongoose, connect, FilterQuery} from "mongoose";
-import CasbinRule, {IModel} from './model'
-import {AdapterError, InvalidAdapterTypeError} from "./errors";
-import {ClientSession} from "mongoose";
+import { BatchAdapter, FilteredAdapter, Helper, logPrint, Model, UpdatableAdapter } from "casbin";
+import { ConnectOptions, Mongoose, connect, FilterQuery } from "mongoose";
+import CasbinRule, { IModel } from './model'
+import { AdapterError, InvalidAdapterTypeError } from "./errors";
+import { ClientSession } from "mongoose";
 
 export interface MongooseAdapterOptions {
   filtered?: boolean,
@@ -107,7 +107,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
   static async newAdapter(uri: string, options: ConnectOptions = {}, adapterOptions: MongooseAdapterOptions = {}) {
     const adapter = new MongooseAdapter(uri, options);
     await adapter._open();
-    const {filtered = false, synced = false, autoAbort = false, autoCommit = false} = adapterOptions;
+    const { filtered = false, synced = false, autoAbort = false, autoCommit = false } = adapterOptions;
     adapter.setFiltered(filtered);
     adapter.setSynced(synced);
     adapter.setAutoAbort(autoAbort);
@@ -128,7 +128,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
    */
   static async newFilteredAdapter(uri: string, options = {}) {
-    const adapter = await MongooseAdapter.newAdapter(uri, options, {filtered: true});
+    const adapter = await MongooseAdapter.newAdapter(uri, options, { filtered: true });
     await adapter._open();
 
     return adapter;
@@ -150,7 +150,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
    */
   static async newSyncedAdapter(uri: string, options = {}, autoAbort = true, autoCommit = true) {
-    return await MongooseAdapter.newAdapter(uri, options, {synced: true, autoAbort, autoCommit});
+    return await MongooseAdapter.newAdapter(uri, options, { synced: true, autoAbort, autoCommit });
   }
 
   /**
@@ -276,7 +276,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
 
     for (const word of [line.v0, line.v1, line.v2, line.v3, line.v4, line.v5]) {
       if (word !== undefined) {
-        lineText = `${lineText},${word}`
+        lineText = `${lineText},"${word}"`
       } else {
         break
       }
@@ -332,7 +332,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * @returns {Object} Returns a created CasbinRule record for MongoDB
    */
   savePolicyLine(pType: string, rule: string[]) {
-    const model = new CasbinRule({ptype: pType});
+    const model = new CasbinRule({ ptype: pType });
 
     if (rule.length > 0) {
       model.v0 = rule[0];
@@ -469,7 +469,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     const options: sessionOption = {};
     try {
       if (this.isSynced) options.session = await this.getTransaction();
-      const {ptype, v0, v1, v2, v3, v4, v5} = this.savePolicyLine(pType, oldRule);
+      const { ptype, v0, v1, v2, v3, v4, v5 } = this.savePolicyLine(pType, oldRule);
       const newRuleLine = this.savePolicyLine(pType, newRule);
       const newModel = {
         ptype: newRuleLine.ptype,
@@ -481,7 +481,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
         v5: newRuleLine.v5
       }
 
-      await CasbinRule.updateOne({ptype, v0, v1, v2, v3, v4, v5}, newModel, options);
+      await CasbinRule.updateOne({ ptype, v0, v1, v2, v3, v4, v5 }, newModel, options);
 
       this.autoCommit && options.session && await options.session.commitTransaction();
     } catch (err) {
@@ -504,9 +504,9 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     try {
       if (this.isSynced) options.session = await this.getTransaction();
 
-      const {ptype, v0, v1, v2, v3, v4, v5} = this.savePolicyLine(pType, rule);
+      const { ptype, v0, v1, v2, v3, v4, v5 } = this.savePolicyLine(pType, rule);
 
-      await CasbinRule.deleteMany({ptype, v0, v1, v2, v3, v4, v5}, options);
+      await CasbinRule.deleteMany({ ptype, v0, v1, v2, v3, v4, v5 }, options);
 
       this.autoCommit && options.session && await options.session.commitTransaction();
     } catch (err) {
@@ -554,7 +554,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     const options: sessionOption = {};
     try {
       if (this.isSynced) options.session = await this.getTransaction();
-      const where: policyLine = pType ? {ptype: pType} : {};
+      const where: policyLine = pType ? { ptype: pType } : {};
 
       if (fieldIndex <= 0 && fieldIndex + fieldValues.length > 0 && fieldValues[0 - fieldIndex]) {
         where.v0 = fieldValues[0 - fieldIndex];

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { BatchAdapter, FilteredAdapter, Helper, logPrint, Model, UpdatableAdapter } from "casbin";
-import { ConnectOptions, Mongoose, connect, FilterQuery } from "mongoose";
-import CasbinRule, { IModel } from './model'
-import { AdapterError, InvalidAdapterTypeError } from "./errors";
-import { ClientSession } from "mongoose";
+import {BatchAdapter, FilteredAdapter, Helper, logPrint, Model, UpdatableAdapter} from "casbin";
+import {ConnectOptions, Mongoose, connect, FilterQuery} from "mongoose";
+import CasbinRule, {IModel} from './model'
+import {AdapterError, InvalidAdapterTypeError} from "./errors";
+import {ClientSession} from "mongoose";
 
 export interface MongooseAdapterOptions {
   filtered?: boolean,
@@ -107,7 +107,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
   static async newAdapter(uri: string, options: ConnectOptions = {}, adapterOptions: MongooseAdapterOptions = {}) {
     const adapter = new MongooseAdapter(uri, options);
     await adapter._open();
-    const { filtered = false, synced = false, autoAbort = false, autoCommit = false } = adapterOptions;
+    const {filtered = false, synced = false, autoAbort = false, autoCommit = false} = adapterOptions;
     adapter.setFiltered(filtered);
     adapter.setSynced(synced);
     adapter.setAutoAbort(autoAbort);
@@ -128,7 +128,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
    */
   static async newFilteredAdapter(uri: string, options = {}) {
-    const adapter = await MongooseAdapter.newAdapter(uri, options, { filtered: true });
+    const adapter = await MongooseAdapter.newAdapter(uri, options, {filtered: true});
     await adapter._open();
 
     return adapter;
@@ -150,7 +150,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * const adapter = await MongooseAdapter.newFilteredAdapter('MONGO_URI', { mongoose_options: 'here' });
    */
   static async newSyncedAdapter(uri: string, options = {}, autoAbort = true, autoCommit = true) {
-    return await MongooseAdapter.newAdapter(uri, options, { synced: true, autoAbort, autoCommit });
+    return await MongooseAdapter.newAdapter(uri, options, {synced: true, autoAbort, autoCommit});
   }
 
   /**
@@ -332,7 +332,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
    * @returns {Object} Returns a created CasbinRule record for MongoDB
    */
   savePolicyLine(pType: string, rule: string[]) {
-    const model = new CasbinRule({ ptype: pType });
+    const model = new CasbinRule({ptype: pType});
 
     if (rule.length > 0) {
       model.v0 = rule[0];
@@ -469,7 +469,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     const options: sessionOption = {};
     try {
       if (this.isSynced) options.session = await this.getTransaction();
-      const { ptype, v0, v1, v2, v3, v4, v5 } = this.savePolicyLine(pType, oldRule);
+      const {ptype, v0, v1, v2, v3, v4, v5} = this.savePolicyLine(pType, oldRule);
       const newRuleLine = this.savePolicyLine(pType, newRule);
       const newModel = {
         ptype: newRuleLine.ptype,
@@ -481,7 +481,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
         v5: newRuleLine.v5
       }
 
-      await CasbinRule.updateOne({ ptype, v0, v1, v2, v3, v4, v5 }, newModel, options);
+      await CasbinRule.updateOne({ptype, v0, v1, v2, v3, v4, v5}, newModel, options);
 
       this.autoCommit && options.session && await options.session.commitTransaction();
     } catch (err) {
@@ -504,9 +504,9 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     try {
       if (this.isSynced) options.session = await this.getTransaction();
 
-      const { ptype, v0, v1, v2, v3, v4, v5 } = this.savePolicyLine(pType, rule);
+      const {ptype, v0, v1, v2, v3, v4, v5} = this.savePolicyLine(pType, rule);
 
-      await CasbinRule.deleteMany({ ptype, v0, v1, v2, v3, v4, v5 }, options);
+      await CasbinRule.deleteMany({ptype, v0, v1, v2, v3, v4, v5}, options);
 
       this.autoCommit && options.session && await options.session.commitTransaction();
     } catch (err) {
@@ -554,7 +554,7 @@ export class MongooseAdapter implements BatchAdapter, FilteredAdapter, Updatable
     const options: sessionOption = {};
     try {
       if (this.isSynced) options.session = await this.getTransaction();
-      const where: policyLine = pType ? { ptype: pType } : {};
+      const where: policyLine = pType ? {ptype: pType} : {};
 
       if (fieldIndex <= 0 && fieldIndex + fieldValues.length > 0 && fieldValues[0 - fieldIndex]) {
         where.v0 = fieldValues[0 - fieldIndex];

--- a/src/model.ts
+++ b/src/model.ts
@@ -15,7 +15,7 @@
 import {Schema, Document, model} from 'mongoose';
 
 export interface IModel extends Document {
-  p_type: string;
+  ptype: string;
   v0: string;
   v1: string;
   v2: string;
@@ -25,7 +25,7 @@ export interface IModel extends Document {
 }
 
 const schema = new Schema({
-  p_type: {
+  ptype: {
     type: Schema.Types.String,
     required: true,
     index: true

--- a/test/integration/adapter.test.js
+++ b/test/integration/adapter.test.js
@@ -58,7 +58,7 @@ describe('MongooseAdapter', () => {
     assert.deepEqual(await enforcer.getPolicy(), [['sub', 'obj', 'act']]);
 
     const rulesAfter = await CasbinRule.find({
-      p_type: 'p',
+      ptype: 'p',
       v0: 'sub',
       v1: 'obj',
       v2: 'act'
@@ -81,7 +81,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(await e.getModel());
     const rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -154,7 +154,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(await e.getModel());
     const rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -234,7 +234,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(await e.getModel());
     const rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -299,7 +299,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(e.getModel());
     const rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write']
     ]);
@@ -394,7 +394,7 @@ describe('MongooseAdapter', () => {
     assert.deepEqual(await enforcer.getPolicy(), [['sub', 'obj', 'act']]);
 
     const rulesAfter = await CasbinRule.find({
-      p_type: 'p',
+      ptype: 'p',
       v0: 'sub',
       v1: 'obj',
       v2: 'act'
@@ -404,7 +404,7 @@ describe('MongooseAdapter', () => {
     assert.deepEqual(await enforcer.getPolicy(), [['sub1', 'obj1', 'act1']]);
 
     const rulesAfterUpdate = await CasbinRule.find({
-      p_type: 'p',
+      ptype: 'p',
       v0: 'sub1',
       v1: 'obj1',
       v2: 'act1'
@@ -421,7 +421,7 @@ describe('MongooseAdapter', () => {
     assert.deepEqual(await enforcer.getPolicy(), [['sub', 'obj', 'act']]);
 
     const rulesAfter = await CasbinRule.find({
-      p_type: 'p',
+      ptype: 'p',
       v0: 'sub',
       v1: 'obj',
       v2: 'act'
@@ -431,7 +431,7 @@ describe('MongooseAdapter', () => {
     assert.deepEqual(await enforcer.getPolicy(), []);
 
     const rulesAfterDelete = await CasbinRule.find({
-      p_type: 'p',
+      ptype: 'p',
       v0: 'sub',
       v1: 'obj',
       v2: 'act'
@@ -453,7 +453,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(e.getModel());
     let rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -464,7 +464,7 @@ describe('MongooseAdapter', () => {
     // Two rules: {'data2_admin', 'data2', 'read'}, {'data2_admin', 'data2', 'write'} are deleted.
     await a.removeFilteredPolicy(undefined, undefined, 0, 'data2_admin');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['g', 'alice', 'data2_admin', undefined]]);
@@ -475,7 +475,7 @@ describe('MongooseAdapter', () => {
     // One rule: {'alice', 'data1', 'read'} is deleted.
     await a.removeFilteredPolicy(undefined, undefined, 1, 'data1');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'bob', 'data2', 'write'],
       ['g', 'alice', 'data2_admin', undefined]]);
     e = await newEnforcer(rbacModel, a);
@@ -485,7 +485,7 @@ describe('MongooseAdapter', () => {
     // One rule: {'bob', 'data2', 'write'} is deleted.
     await a.removeFilteredPolicy(undefined, undefined, 2, 'write');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['g', 'alice', 'data2_admin', undefined]]);
     e = await newEnforcer(rbacModel, a);
     assert.deepEqual(await e.getPolicy(), []);
@@ -505,7 +505,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(e.getModel());
     let rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -517,7 +517,7 @@ describe('MongooseAdapter', () => {
     // One policy: {'alice', 'data2', 'read'} and One Grouping Policy {'alice', 'data2_admin'} are deleted.
     await e.deleteUser('alice');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
       ['p', 'data2_admin', 'data2', 'write']]);
@@ -531,7 +531,7 @@ describe('MongooseAdapter', () => {
     // One rule: {'bob', 'data2', 'write'} is deleted.
     await e.deleteUser('bob');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'data2_admin', 'data2', 'read'],
       ['p', 'data2_admin', 'data2', 'write']]);
     e = await newEnforcer(rbacModel, a);
@@ -554,7 +554,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(e.getModel());
     let rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write'],
       ['p', 'data2_admin', 'data2', 'read'],
@@ -566,7 +566,7 @@ describe('MongooseAdapter', () => {
     // One policy: {'alice', 'data2', 'read'} and One Grouping Policy {'alice', 'data2_admin'} are deleted.
     await e.deleteRole('data2_admin');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2]), [
       ['p', 'alice', 'data1', 'read'],
       ['p', 'bob', 'data2', 'write']]);
     assert.deepEqual(await e.getPolicy(), [
@@ -588,7 +588,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(await e.getModel());
     const rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'admin', 'domain1', 'data1', 'read', 'allow'],
       ['p', 'admin', 'domain1', 'data1', 'write', 'allow'],
       ['p', 'admin', 'domain2', 'data2', 'read', 'allow'],
@@ -666,7 +666,7 @@ describe('MongooseAdapter', () => {
     // The current policy means the policy in the Node-Casbin enforcer (aka in memory).
     await a.savePolicy(e.getModel());
     let rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'admin', 'domain1', 'data1', 'read', 'allow'],
       ['p', 'admin', 'domain1', 'data1', 'write', 'allow'],
       ['p', 'admin', 'domain2', 'data2', 'read', 'allow'],
@@ -689,18 +689,18 @@ describe('MongooseAdapter', () => {
     // are deleted.
     await a.removeFilteredPolicy(undefined, undefined, 0, 'admin');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'alice', 'domain2', 'data2', 'write', 'deny'],
       ['g', 'alice', 'admin', 'domain2', undefined, undefined]]);
     e = await newEnforcer(rbacDenyDomainModel, a);
     assert.deepEqual(await e.getPolicy(), [['alice', 'domain2', 'data2', 'write', 'deny']]);
     await a.removeFilteredPolicy(undefined, 'g');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'alice', 'domain2', 'data2', 'write', 'deny']]);
     await a.removeFilteredPolicy(undefined, 'p');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), []);
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), []);
 
     // Reload the mode + policy
     e = await newEnforcer(rbacDenyDomainModel, rbacDenyDomainPolicy);
@@ -713,7 +713,7 @@ describe('MongooseAdapter', () => {
     // are deleted.
     await a.removeFilteredPolicy(undefined, undefined, 1, 'domain2');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'admin', 'domain1', 'data1', 'read', 'allow'],
       ['p', 'admin', 'domain1', 'data1', 'write', 'allow'],
       ['g', 'alice', 'admin', 'domain2', undefined, undefined]]);
@@ -729,7 +729,7 @@ describe('MongooseAdapter', () => {
     // are deleted.
     await a.removeFilteredPolicy(undefined, undefined, 2, 'data1');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['g', 'alice', 'admin', 'domain2', undefined, undefined]]);
     e = await newEnforcer(rbacDenyDomainModel, a);
     assert.deepEqual(await e.getPolicy(), []);
@@ -737,7 +737,7 @@ describe('MongooseAdapter', () => {
     await a.removeFilteredPolicy(undefined, 'g');
     await a.removeFilteredPolicy(undefined, 'p');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), []);
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), []);
 
     e = await newEnforcer(rbacDenyDomainModel, rbacDenyDomainPolicy);
     await a.savePolicy(e.getModel());
@@ -749,7 +749,7 @@ describe('MongooseAdapter', () => {
     // are deleted.
     await a.removeFilteredPolicy(undefined, undefined, 3, 'read');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'admin', 'domain1', 'data1', 'write', 'allow'],
       ['p', 'admin', 'domain2', 'data2', 'write', 'allow'],
       ['p', 'alice', 'domain2', 'data2', 'write', 'deny'],
@@ -766,7 +766,7 @@ describe('MongooseAdapter', () => {
     // is deleted.
     await a.removeFilteredPolicy(undefined, undefined, 4, 'deny');
     rulesAfter = await CasbinRule.find({});
-    assert.deepEqual(rulesAfter.map(rule => [rule.p_type, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
+    assert.deepEqual(rulesAfter.map(rule => [rule.ptype, rule.v0, rule.v1, rule.v2, rule.v3, rule.v4]), [
       ['p', 'admin', 'domain1', 'data1', 'write', 'allow'],
       ['p', 'admin', 'domain2', 'data2', 'write', 'allow'],
       ['g', 'alice', 'admin', 'domain2', undefined, undefined]]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,11 +399,6 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
   integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
 
-"@types/node@< 17.0.6":
-  version "17.0.5"
-  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz#57ca67ec4e57ad9e4ef5a6bab48a15387a1c83e0"
-  integrity sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==
-
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -772,7 +767,7 @@ browserslist@^4.17.5:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
-bson@^4.2.2, bson@^4.6.0:
+bson@^4.2.2, bson@^4.6.1:
   version "4.6.1"
   resolved "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz#2b5da517539bb0f7f3ffb54ac70a384ca899641c"
   integrity sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==
@@ -2184,6 +2179,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2578,10 +2578,10 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
-kareem@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/kareem/-/kareem-2.3.3.tgz#a4432d7965a5bb06fc2b4eeae71317344c9a756a"
-  integrity sha512-uESCXM2KdtOQ8LOvKyTUXEeg0MkYp4wGglTIpGcYHvjJcS5sn2Wkfrfit8m4xSbaNDAw2KdI9elgkOxZbrFYbg==
+kareem@2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.4.tgz#b38c436fb4758775d919b2828b4009db59b52694"
+  integrity sha512-Vcrt8lcpVl0s8ePx634BxwRqmFo+5DcOhlmNadehxreMTIQi/9hOL/B3hZQQbK5DgMS7Lem3xABXV7/S3jy+7g==
 
 klaw@^4.0.1:
   version "4.0.1"
@@ -2867,39 +2867,38 @@ mocha@^8.3.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-mongodb-connection-string-url@^2.3.2:
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.1.tgz#6b3c6c40133a0ad059fe9a0abda64b2a1cb4e8b4"
-  integrity sha512-d5Kd2bVsKcSA7YI/yo57fSTtMwRQdFkvc5IZwod1RRxJtECeWPPSo7zqcUGJELifRA//Igs4spVtYAmvFCatug==
+mongodb-connection-string-url@^2.4.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz#f075c8d529e8d3916386018b8a396aed4f16e5ed"
+  integrity sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==
   dependencies:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-4.2.2.tgz#cd70568bd96003877e35358ad17a0c5de35c6dfd"
-  integrity sha512-zt8rCTnTKyMQppyt63qMnrLM5dbADgUk18ORPF1XbtHLIYCyc9hattaYHi0pqMvNxDpgGgUofSVzS+UQErgTug==
+mongodb@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.3.1.tgz#e346f76e421ec6f47ddea5c8f5140e6181aaeb94"
+  integrity sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==
   dependencies:
-    bson "^4.6.0"
+    bson "^4.6.1"
     denque "^2.0.1"
-    mongodb-connection-string-url "^2.3.2"
+    mongodb-connection-string-url "^2.4.1"
+    socks "^2.6.1"
   optionalDependencies:
     saslprep "^1.0.3"
 
-mongoose@^6.0.12:
-  version "6.1.8"
-  resolved "https://registry.npmjs.org/mongoose/-/mongoose-6.1.8.tgz#8565c7610ceb81a9b0416ceb4bf0b709c8b83f6a"
-  integrity sha512-/voqwU2dtet3zAR73r8jdPhqluU1VzIAnk7ecXPJBgyXKREnwQrz40lfW7fLpaqhmMhsAbA+JQ7ICUn2vAVFLw==
+mongoose@^6.2.4:
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.2.4.tgz#c6ff4f84ab47b6c760e773424b0fd1f392d98563"
+  integrity sha512-3hA3IGxBzZdlp1+/I9qn53NjEAd01qvKAH2WUCPahjVO8+uAmR0B4m+1bC3x9a4r0ExY8QYQ2ryG3E/v5Tj+jA==
   dependencies:
-    "@types/node" "< 17.0.6"
     bson "^4.2.2"
-    kareem "2.3.3"
-    mongodb "4.2.2"
+    kareem "2.3.4"
+    mongodb "4.3.1"
     mpath "0.8.4"
     mquery "4.0.2"
-    ms "2.1.2"
-    regexp-clone "1.0.0"
-    sift "13.5.2"
+    ms "2.1.3"
+    sift "16.0.0"
 
 mpath@0.8.4:
   version "0.8.4"
@@ -3388,11 +3387,6 @@ reduce-without@^1.0.1:
   dependencies:
     test-value "^2.0.0"
 
-regexp-clone@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
-  integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
-
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -3615,10 +3609,10 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-sift@13.5.2:
-  version "13.5.2"
-  resolved "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz#24a715e13c617b086166cd04917d204a591c9da6"
-  integrity sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==
+sift@16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-16.0.0.tgz#447991577db61f1a8fab727a8a98a6db57a23eb8"
+  integrity sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ==
 
 signal-exit@^3.0.2:
   version "3.0.6"
@@ -3650,6 +3644,19 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+socks@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
+  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.2.0"
 
 sort-array@^4.1.1:
   version "4.1.4"


### PR DESCRIPTION
### Issue:

#### Model

```
[request_definition]
r = sub, cid, lid, obj, act

[policy_definition]
p = sub, cid, lid, obj, act, rule, eft

[role_definition]
g = _, _, _

[policy_effect]
e = some(where (p.eft == allow)) && !some(where (p.eft == deny))

[matchers]
m = g(r.sub.id+'::'+r.sub.type, p.sub, r.cid+'::'+r.lid)&& eval(p.rule) && keyMatch(r.cid, p.cid)&& keyMatch(r.lid, p.lid) && regexMatch(r.act, p.act) && keyMatch2(r.obj, p.obj)
```

#### Policy

```
p, employee, *, *, /e/:eid, update, "r.sub.id == keyGet2(r.obj, p.obj, 'eid')"
p, employee, *, *, /e/:eid, get, true
p, admin, *, *, /e/:eid, update, true
p, admin, cid3, lid1, /kiosk/:kid, (get)|(update), true


g, admin, location-admin, *
g, location-admin, receptionist, *
g, receptionist, employee, *
g, billing-admin, employee, *
g, alice, admin, cid3::*
```

While loading above policy from database, `loadPolicyLine` from `Helper` class will parse `r.sub.id == keyGet2(r.obj, p.obj, 'eid')` into two tokens as it contains delimiter.

We can workaround this by wrapping `r.sub.id == keyGet2(r.obj, p.obj, 'eid')` with quotes but `hasPolicy` will fail because provided policy line contains extra quotes but parsed policy line will not have them.

### Solution

Wrap all tokens of policy line before joining them and passing policy line to the csv parser