### PR TITLE
docs: replace gitter links with discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mongoose Adapter
 [![NPM download][download-image]][download-url]
 [![codebeat badge](https://codebeat.co/badges/c17c9ee1-da42-4db3-8047-9574ad2b23b1)](https://codebeat.co/projects/github-com-node-casbin-mongoose-adapter-master)
 [![Coverage Status](https://coveralls.io/repos/github/node-casbin/mongoose-adapter/badge.svg?branch=master)](https://coveralls.io/github/node-casbin/mongoose-adapter?branch=master)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/casbin/lobby)
+[![Discord](https://img.shields.io/discord/1022748306096537660?logo=discord&label=discord&color=5865F2)](https://discord.gg/S5UjpzGZjN)
 [![tests](https://github.com/node-casbin/mongoose-adapter/actions/workflows/main.yml/badge.svg)](https://github.com/node-casbin/mongoose-adapter/actions/workflows/main.yml)
 
 [npm-image]: https://img.shields.io/npm/v/casbin-mongoose-adapter.svg?style=flat-square


### PR DESCRIPTION
resolved: https://github.com/casbin/casbin-website-v2/issues/179